### PR TITLE
2 bug fixes - parameter and parsing and calling of current python

### DIFF
--- a/client.py
+++ b/client.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Optional, Literal
 from contextlib import AsyncExitStack
 from urllib.parse import urlparse
 
+import sys
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 from mcp.client.sse import sse_client
@@ -36,7 +37,7 @@ class MCPClient:
         if not (is_python or is_js):
             raise ValueError("Server script must be a .py or .js file")
 
-        command = "python" if is_python else "node"
+        command = sys.executable if is_python else "node"
         server_params = StdioServerParameters(
             command=command,
             args=[server_script_path],
@@ -204,7 +205,7 @@ class MCPClient:
         await self.exit_stack.aclose()
 
 async def main():
-    if len(sys.argv) < 3:
+    if len(sys.argv) < 2:
         print("Usage: python client.py server_name1:path_to_server1.py [server_name2:path_to_server2.py ...]")
         print("Example: python client.py weather:servers/weather_server.py calculator:servers/calculator_server.py")
         sys.exit(1)


### PR DESCRIPTION
Thank you for the nice code.

I noticed 2 minor issues and fixed them:
- `python client.py weather:servers/weather_server.py` would actually lead to 2 parameters (after python). This should be processed.
- I installed all required packages in the current environment, but not on my computer. If the normal `python` gets used, the server might not find the required package.  By using `sys.executable`, the python of the current environment (with all its packages) is used.